### PR TITLE
Add Phase 1 Python data fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+venv/
+ENV/
+.env
+.env.*
+
+# Fortran build artifacts
+*.o
+*.mod
+*.a
+*.so
+*.exe
+*.out
+
+# Go build artifacts
+bin/
+*.exe
+*.test
+
+# IDE files
+.DS_Store
+.idea/
+.vscode/
+
+# Data files
+/data/raw/
+/data/processed/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: fetch sim run
+
+fetch:
+	python scripts/fetch_data.py $(ARGS)
+
+sim:
+	@echo "Fortran simulation build not implemented yet"
+
+run:
+	@echo "Go client not implemented yet"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# quantforge
+# QuantForge
+
+QuantForge is a cross-language quant trading research platform. This repository
+currently implements **Phase 1**: data ingestion and management using Python.
+
+## Structure
+
+```
+quantforge/
+├── cmd/              # Go clients (future phases)
+├── data/
+│   ├── processed/    # Output of resampling
+│   └── raw/          # Raw historical data
+├── scripts/          # Python utilities
+│   ├── fetch_data.py # Fetch and resample data
+│   └── preprocess.py # Standalone resampling helper
+├── sim/              # Fortran simulation engine (future)
+├── main.py           # Entry point running fetch_data
+├── Makefile          # Convenience tasks
+```
+
+## Phase 1 Usage
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt  # currently requires pandas and yfinance
+```
+
+2. Fetch historical data:
+
+```bash
+python scripts/fetch_data.py fetch AAPL --start 2020-01-01 --end 2020-12-31 --interval 1d
+```
+
+This saves data to `data/raw/AAPL_2020-01-01_2020-12-31.csv`.
+
+3. Resample existing CSV:
+
+```bash
+python scripts/fetch_data.py resample data/raw/AAPL_2020-01-01_2020-12-31.csv --interval 1h
+```
+
+Resampled output is written to `data/processed/`.
+
+The `Makefile` includes a `fetch` target as a shorthand for running the
+fetcher. Future phases will add Fortran backtesting and Go real-time
+components.

--- a/cmd/quantforge.go
+++ b/cmd/quantforge.go
@@ -1,0 +1,6 @@
+// Placeholder for Go CLI (Phase 3)
+package main
+
+func main() {
+    // TODO: implement real-time client
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Entry point for QuantForge utilities (Phase 1)."""
+from scripts.fetch_data import main
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+yfinance

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""QuantForge Data Fetcher
+
+Fetch historical OHLCV data using yfinance and optionally resample it.
+"""
+import argparse
+from pathlib import Path
+import pandas as pd
+import yfinance as yf
+
+DATA_DIR = Path(__file__).resolve().parents[1] / 'data'
+RAW_DIR = DATA_DIR / 'raw'
+PROCESSED_DIR = DATA_DIR / 'processed'
+
+
+def fetch_data(ticker: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    """Fetch OHLCV data via yfinance.
+
+    The ``yfinance.download`` API can return a multi-index column layout. Using
+    ``Ticker.history`` keeps the output flat which simplifies downstream
+    processing.
+    """
+    history = yf.Ticker(ticker).history(
+        start=start,
+        end=end,
+        interval=interval,
+        auto_adjust=False,
+        actions=False,
+    )
+    df = history[['Open', 'High', 'Low', 'Close', 'Volume']]
+    if df.empty:
+        raise ValueError(
+            f"No data returned for {ticker} {start} {end} {interval}"
+        )
+    return df
+
+
+def save_csv(df: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path)
+    print(f"Saved {len(df)} rows to {path}")
+
+
+def resample_data(df: pd.DataFrame, interval: str) -> pd.DataFrame:
+    agg = {
+        'Open': 'first',
+        'High': 'max',
+        'Low': 'min',
+        'Close': 'last',
+        'Volume': 'sum',
+    }
+    resampled = df.resample(interval).agg(agg)
+    resampled = resampled.dropna()
+    return resampled
+
+
+def default_raw_path(ticker: str, start: str, end: str) -> Path:
+    fname = f"{ticker}_{start}_{end}.csv"
+    return RAW_DIR / fname
+
+
+def default_processed_path(raw_path: Path, interval: str) -> Path:
+    fname = raw_path.stem + f"_{interval}.csv"
+    return PROCESSED_DIR / fname
+
+
+def cmd_fetch(args: argparse.Namespace) -> None:
+    df = fetch_data(args.ticker, args.start, args.end, args.interval)
+    csv_path = Path(args.output) if args.output else default_raw_path(args.ticker, args.start, args.end)
+    save_csv(df, csv_path)
+    if args.resample:
+        r_df = resample_data(df, args.resample)
+        r_path = default_processed_path(csv_path, args.resample)
+        save_csv(r_df, r_path)
+
+
+def cmd_resample(args: argparse.Namespace) -> None:
+    csv_path = Path(args.input)
+    df = pd.read_csv(csv_path, parse_dates=['Date'], index_col='Date')
+    r_df = resample_data(df, args.interval)
+    out_path = Path(args.output) if args.output else default_processed_path(csv_path, args.interval)
+    save_csv(r_df, out_path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='QuantForge data utilities')
+    sub = parser.add_subparsers(dest='command', required=True)
+
+    f = sub.add_parser('fetch', help='Fetch data from yfinance')
+    f.add_argument('ticker', help='Ticker symbol')
+    f.add_argument('--start', required=True, help='Start date YYYY-MM-DD')
+    f.add_argument('--end', required=True, help='End date YYYY-MM-DD')
+    f.add_argument('--interval', default='1d', help='Data interval, e.g., 1d, 1h')
+    f.add_argument('--output', help='Output CSV file')
+    f.add_argument('--resample', help='Resample interval (e.g., 1h, 1wk)')
+
+    r = sub.add_parser('resample', help='Resample an existing CSV')
+    r.add_argument('input', help='Path to CSV file')
+    r.add_argument('--interval', required=True, help='New interval like 1h, 1wk')
+    r.add_argument('--output', help='Output CSV file')
+
+    return parser
+
+
+def main(argv=None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == 'fetch':
+        cmd_fetch(args)
+    elif args.command == 'resample':
+        cmd_resample(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Data preprocessing utilities for QuantForge."""
+from pathlib import Path
+import argparse
+import pandas as pd
+
+from fetch_data import resample_data, default_processed_path
+
+
+def preprocess(csv_path: Path, interval: str, output: Path | None = None) -> Path:
+    df = pd.read_csv(csv_path, parse_dates=['Date'], index_col='Date')
+    resampled = resample_data(df, interval)
+    out_path = output if output else default_processed_path(csv_path, interval)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    resampled.to_csv(out_path)
+    print(f"Saved resampled data to {out_path}")
+    return out_path
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description='Resample existing CSV data')
+    parser.add_argument('csv', help='Path to raw CSV data')
+    parser.add_argument('--interval', required=True, help='New interval e.g., 1h')
+    parser.add_argument('--output', help='Output CSV path')
+    args = parser.parse_args(argv)
+    preprocess(Path(args.csv), args.interval, Path(args.output) if args.output else None)
+
+
+if __name__ == '__main__':
+    main()

--- a/sim/engine.f90
+++ b/sim/engine.f90
@@ -1,0 +1,1 @@
+! Placeholder for Fortran simulation engine (Phase 2)


### PR DESCRIPTION
## Summary
- implement data ingestion script `scripts/fetch_data.py`
- add preprocessing helper
- provide entrypoint and basic Makefile
- create placeholders for future Fortran and Go code
- document usage and ignore build/data artifacts

## Testing
- `python -m py_compile scripts/fetch_data.py scripts/preprocess.py main.py`
- `python scripts/fetch_data.py fetch AAPL --start 2024-01-01 --end 2024-01-10 --interval 1d --resample 1W | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6863b985dc50832b840f7b209e612504